### PR TITLE
Add runtime dependencies to gemspec

### DIFF
--- a/rubinius-debugger.gemspec
+++ b/rubinius-debugger.gemspec
@@ -18,7 +18,9 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = "~> 2.0"
 
+  spec.add_runtime_dependency "rubysl-readline", "~> 2.0"
   spec.add_runtime_dependency "rubinius-compiler", "~> 2.0"
+
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
Hi,

There are missing dependencies that causes load errors.

rubysl-readline
rubinius-compiler
