### PR TITLE
Deferred breakpoints: support commands/conditions

### DIFF
--- a/lib/rubinius/debugger.rb
+++ b/lib/rubinius/debugger.rb
@@ -265,7 +265,7 @@ class Rubinius::Debugger
     end
   end
 
-  def set_breakpoint_method(descriptor, method, line=nil, condition=nil)
+  def set_breakpoint_method(descriptor, method, line=nil, condition=nil, commands=nil, index=nil)
     exec = method.executable
 
     unless exec.kind_of?(Rubinius::CompiledCode)
@@ -288,9 +288,14 @@ class Rubinius::Debugger
     bp = BreakPoint.new(descriptor, exec, ip, line, condition)
     bp.activate
 
-    @breakpoints << bp
-
-    info "Set breakpoint #{@breakpoints.size}: #{bp.location}"
+    if index
+      bp.set_commands(commands)
+      @breakpoints[index] = bp
+      info "Set breakpoint #{index+1}: #{bp.location}"
+    else
+      @breakpoints << bp
+      info "Set breakpoint #{@breakpoints.size}: #{bp.location}"
+    end
 
     return bp
   end

--- a/lib/rubinius/debugger/breakpoint.rb
+++ b/lib/rubinius/debugger/breakpoint.rb
@@ -104,7 +104,11 @@ class Rubinius::Debugger
       @name = name
       @line = line
       @list = list
+      @commands = nil
+      @condition = nil
     end
+
+    attr_reader :condition, :commands
 
     def descriptor
       "#{@klass_name}#{@which}#{@name}"
@@ -129,7 +133,8 @@ class Rubinius::Debugger
 
       @debugger.info "Resolved breakpoint for #{@klass_name}#{@which}#{@name}"
 
-      @debugger.set_breakpoint_method descriptor, method, @line
+      index = @debugger.breakpoints.index(self)
+      @debugger.set_breakpoint_method descriptor, method, @line, @condition, @commands, index
 
       return true
     end
@@ -142,6 +147,22 @@ class Rubinius::Debugger
       if @list
         @list.delete self
       end
+    end
+
+    def set_commands(commands)
+      @commands = commands
+    end
+
+    def has_commands?
+      !@commands.nil?
+    end
+
+    def set_condition(condition)
+      @condition = condition
+    end
+
+    def has_condition?
+      !@condition.nil?
     end
   end
 end


### PR DESCRIPTION
Fixes a few things around deferred breakpoints:
1. `info bp` raised because deferred bps don't quack like a regular one
2. `cond` and `command` couldn't be set on deferred bps; this now stores them, and just installs them onto the real breakpoint once resolved
3. The real breakpoint replaces the deferred one, instead of adding a new entry.

Gist of before & after on a simple script: https://gist.github.com/pd/5b23e26dd5958bba8f02
