### PR TITLE
Write new commands into readline history

### DIFF
--- a/lib/rubinius/debugger.rb
+++ b/lib/rubinius/debugger.rb
@@ -193,6 +193,7 @@ class Rubinius::Debugger
       cmd = @last_command
     else
       @last_command = cmd
+      Readline::History << cmd
     end
 
     command, args = cmd.to_s.strip.split(/\s+/, 2)


### PR DESCRIPTION
If I've entered a command, not just hit enter to repeat the last one, add it to the in-process readline history. Previously, readline history wasn't available until I'd quit and restart to load it all back in from `~/.rbx_debug`. `~/.rbx_debug` is still only written to after valid commands, but readline history includes whatever I happen to type in, so I can edit my stupid typos.
