### PR TITLE
Fix Readline::HISTORY capitalization

### DIFF
--- a/lib/rubinius/debugger.rb
+++ b/lib/rubinius/debugger.rb
@@ -193,7 +193,7 @@ class Rubinius::Debugger
       cmd = @last_command
     else
       @last_command = cmd
-      Readline::History << cmd
+      Readline::HISTORY << cmd
     end
 
     command, args = cmd.to_s.strip.split(/\s+/, 2)


### PR DESCRIPTION
Using Readline::HISTORY throws
`uninitialized constant Readline::History (NameError)`