### PR TITLE
Replace deprecated const Rubinius::KERNEL_PATH with Rubinius::CORE_PATH

### DIFF
--- a/lib/rubinius/debugger.rb
+++ b/lib/rubinius/debugger.rb
@@ -17,7 +17,7 @@ class Rubinius::Debugger
   include Rubinius::Debugger::Display
 
   # Find the source for the kernel.
-  ROOT_DIR = File.expand_path("../", Rubinius::KERNEL_PATH)
+  ROOT_DIR = File.expand_path("../", Rubinius::CORE_PATH)
 
   # Create a new debugger object. The debugger starts up a thread
   # which is where the command line interface executes from. Other


### PR DESCRIPTION
As it was discussed at https://github.com/rubinius/rubinius/pull/3686.
